### PR TITLE
usage of unkeyed struct literals breaks compilation due to additional field in PublicKey struct

### DIFF
--- a/ep11cmds/ep11cprb.go
+++ b/ep11cmds/ep11cprb.go
@@ -665,7 +665,7 @@ func buildAdminRspBlk(htpResponse string, de common.DomainEntry) (AdminRspBlk, e
 		} else {
 			return adminRspBlk, errors.New("Unrecognized format of crypto module public key")
 		}
-		pubkey := ecdsa.PublicKey{elliptic.P521(), &x, &y}
+		pubkey := ecdsa.PublicKey{Curve: elliptic.P521(), X: &x, Y: &y} 
 
 		// Verify the signature
 		var r, s big.Int

--- a/ep11cmds/verifyCertificate.go
+++ b/ep11cmds/verifyCertificate.go
@@ -119,7 +119,7 @@ func verifyECCCertificate(authToken string, urlStart string, de common.DomainEnt
 	var x, y big.Int
 	x.SetBytes(xbytes)
 	y.SetBytes(ybytes)
-	pubkey := ecdsa.PublicKey{elliptic.P521(), &x, &y}
+	pubkey := ecdsa.PublicKey{Curve: elliptic.P521(), X: &x, Y: &y}
 
 	// Calculate the SHA-512 hash of the certificate body
 	hasher := sha512.New()

--- a/ep11cmds/verifyOA2Certificate.go
+++ b/ep11cmds/verifyOA2Certificate.go
@@ -132,7 +132,7 @@ func VerifyOA2Certificate(authToken string, urlStart string, de common.DomainEnt
 	var x, y big.Int
 	x.SetBytes(xbytes)
 	y.SetBytes(ybytes)
-	pubkey := ecdsa.PublicKey{elliptic.P521(), &x, &y}
+	pubkey := ecdsa.PublicKey{Curve: elliptic.P521(), X: &x, Y: &y}
 
 	// Calculate the SHA-512 hash of the certificate body
 	hasher := sha512.New()


### PR DESCRIPTION
When boring crypto is used, an additional literal is added to the PublicKey structure:

~~~
// PublicKey represents an ECDSA public key.
type PublicKey struct {
	elliptic.Curve
	X, Y *big.Int
	boring unsafe.Pointer
}
~~~

This results in compilation failing when compiled with the Red Hat go-toolset.

The change in this PR is to define this structure with the use of keyed literals as is recommended in the go [compatibility guide](https://golang.org/doc/go1compat) which accounts for the need to add fields to exported structs.